### PR TITLE
new: adding org templates for PRs and GHA

### DIFF
--- a/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--- Please include the details below in your pull request once it's ready for review. --->
+
+<!--- Brief summary of your pull request for our release changelog --->
+
+
+
+<!--- TLDR; what does this PR do? --->
+
+
+
+<!--- TLDR; who does this PR affect? --->

--- a/workflow-templates/add-to-project-ci.properties.json
+++ b/workflow-templates/add-to-project-ci.properties.json
@@ -1,0 +1,4 @@
+{
+    "name": "Add to Project Workflow",
+    "description": "Workflow that adds new issues and PRs to the PR/Issue Triage Project Board."
+}

--- a/workflow-templates/add-to-project-ci.yml
+++ b/workflow-templates/add-to-project-ci.yml
@@ -1,0 +1,21 @@
+name: Add new issues and PRs to triage project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v3
+        with:
+          project-url: https://github.com/orgs/qiime2/projects/36
+          github-token:
+          labeled: no-triage
+          label-operator: NOT

--- a/workflow-templates/add-to-project-ci.yml
+++ b/workflow-templates/add-to-project-ci.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/add-to-project@v3
         with:
           project-url: https://github.com/orgs/qiime2/projects/36
-          github-token:
-          labeled: no-triage
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: skip-triage
           label-operator: NOT


### PR DESCRIPTION
This PR does the following:

- Adds a pull request template for all repos within the QIIME 2 org. Note that this is the org-wide default template, which can be overridden by individual repo custom templates.
- Adds a github workflows template that routes new issues/PRs to the triage project board for all repos within the QIIME 2 org.
  - This workflow will run whenever a new issue or PR is created (i.e. opened) for all PRs/issues WITHOUT the no-triage tag. This tag should be used by the core development team when submitting issues or PRs that will already be added to the current dev cycle.